### PR TITLE
composerでsmartyをインストール時のパスを見るよう修正

### DIFF
--- a/app/src/View/SmartyView.php
+++ b/app/src/View/SmartyView.php
@@ -28,7 +28,7 @@ use Cake\Network\Request;
 use Cake\Network\Response;
 use Cake\Event\EventManager;
 
-require_once(ROOT . '/vendor'.DS.'smarty'.DS.'Smarty.class.php');
+require_once(ROOT . '/vendor'.DS.'smarty'.DS.'smarty'.DS.'libs'.DS.'Smarty.class.php');
 use \Smarty;
 
 /**
@@ -63,6 +63,7 @@ class SmartyView extends View {
 		$this->_smarty->debugging = true;
 		$this->_smarty->caching = 0;
 		$this->_smarty->clearCompiledTemplate();
+    $this->_smarty->default_modifiers = ['escape:"html"'];
 		
 		$viewOptions['seed'] = '3835d21d4c6997aa6909d3172629a751';
 		parent::__construct($request, $response, $eventManager, $viewOptions);


### PR DESCRIPTION
composerでsmartyをインストールした時にうまくいかなかったので修正してみました。
ctpの代わりにsmartyを使うメリットの１つとして、デフォルト出力エスケープが
一般的かなと思ったので、それも修正してみました。
目的と異なっていたらリジェクトしてください。非常に助かっております。
